### PR TITLE
Remove deeplearning dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
 tnn_utils = CUDAExtension(
-                        name='tt_emb',
+                        name='tt_embeddings',
                         sources=['tt_embeddings.cpp',
                             'tt_embeddings_cuda.cu',
                         ],

--- a/tt_embeddings_ops.py
+++ b/tt_embeddings_ops.py
@@ -9,8 +9,7 @@ import random
 from typing import Dict, List, Optional, Tuple
 from enum import Enum, unique
 
-# pyre-fixme[21]
-import deeplearning.fbtt_embedding.tt_embeddings as tt_embeddings
+import tt_embeddings
 import numpy as np
 import torch
 from torch import nn


### PR DESCRIPTION
Summary:
Resolving the module not found issue in the benchmark:
https://github.com/facebookresearch/FBTT-Embedding/issues/6

Differential Revision: D26237001

