### PR TITLE
Support table batched TT embedding lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,5 +112,34 @@ tt_emb = TTEmbeddingBag(
 
 During forward propagation, the access frequency of embedding vectors will be updated. However, the cache will only be updated when `tt_emb.cache_populate()` is called. The cached rows are determined by the access frequency of the embedding vectors, and the value of each embedding vector would be initialized from TT cores.
 
+### TableBatchedTTEmbeddingBag
+
+Apart from TTEmbeddingBag demonstrated above, there's also a TableBatchedTTEmbeddingBag which groups the lookup operation together for multiple TT embedding tables. It can be more efficient than creating multiple instances of TTEmbeddingBags when each of the TTEmbeddingBags has little computation involved.
+
+To use that, you just need to initialize it as below
+
+``` python
+tt_emb = TableBatchedTTEmbeddingBag(
+        num_tables=100,
+        num_embeddings=1000000,
+        embedding_dim=64,
+        tt_p_shapes=[120, 90, 110],
+        tt_q_shapes=[4, 4, 4],
+        tt_ranks=[12, 14],
+        sparse=False,
+        use_cache=False,
+        weight_dist="uniform"
+    )
+```
+
+The above creates 100 TT embedding tables with the same dimensions underlying. The only additional argument that needs to be passed is `num_tables`
+
+Currently there are some limitations to TableBatchedTTEmbeddingBag.
+
+* The mutiple tables in TableBatchedTTEmbeddingBag must share the same dimensions.
+* No support for software cache yet.
+* No support for "approx-uniform" weight init yet.
+* No support for expanding to full weight yet.
+
 ## License
 FBTT-Embedding is MIT licensed, as found in the LICENSE file.

--- a/tt_embeddings.cpp
+++ b/tt_embeddings.cpp
@@ -12,6 +12,7 @@ using namespace at;
 
 Tensor tt_embeddings_forward_cuda(
     int32_t batch_count,
+    int32_t num_tables,
     int32_t B,
     int32_t D,
     const std::vector<int>& tt_p_shapes,
@@ -21,6 +22,7 @@ Tensor tt_embeddings_forward_cuda(
     int32_t nnz,
     Tensor indices,
     Tensor rowidx,
+    Tensor tableidx,
     const std::vector<Tensor>& tt_cores);
 
 std::vector<Tensor> tt_embeddings_backward_dense_cuda(
@@ -33,6 +35,7 @@ std::vector<Tensor> tt_embeddings_backward_dense_cuda(
     int32_t nnz,
     Tensor indices,
     Tensor offsets,
+    Tensor tableidx,
     Tensor d_output,
     std::vector<Tensor>& tt_cores);
 
@@ -47,6 +50,7 @@ void tt_embeddings_backward_sgd_cuda(
     int32_t nnz,
     Tensor indices,
     Tensor offsets,
+    Tensor tableidx,
     Tensor d_output,
     std::vector<Tensor>& tt_cores);
 
@@ -62,6 +66,7 @@ void tt_embeddings_backward_adagrad_cuda(
     int32_t nnz,
     Tensor indices,
     Tensor offsets,
+    Tensor tableidx,
     Tensor d_output,
     std::vector<Tensor>& optimizer_state,
     std::vector<Tensor>& tt_cores);
@@ -80,10 +85,11 @@ void cache_populate_cuda(
     Tensor cache_state,
     Tensor cache_weight);
 
-std::tuple<Tensor, Tensor, int32_t, c10::optional<Tensor>>
+std::tuple<Tensor, Tensor, Tensor, int32_t, c10::optional<Tensor>>
 preprocess_indices_sync_cuda(
     Tensor colidx,
     Tensor offsets,
+    int32_t num_tables,
     bool warmup,
     Tensor hashtbl,
     Tensor cache_state);


### PR DESCRIPTION
Summary:
Support table batched TT embedding lookup assuming the multiple tables have exactly the same hash size and embedding dim.
- Make each tt_cores 3 dimensional: [num_tables, tt_p_shape[i], ...]
- Handle the additional num_tables dimension correctly in the computation
- Have a TableBatchedTTEmbeddingBag that supports passing num_tables
- Make TTEmbeddingBag as special case of TableBatchedTTEmbeddingBag when num_tables = 1
- Add unit test to compare TableBatchedTTEmbeddingBag with running multiple TTEmbeddingBags

Differential Revision: D27091933

