### PR TITLE
move ATen/CUDAGeneratorImpl.h to ATen/cuda (#860)

### DIFF
--- a/tt_embeddings_cuda.cu
+++ b/tt_embeddings_cuda.cu
@@ -7,10 +7,10 @@ LICENSE file in the root directory of this source tree.
 
 #include <ATen/ATen.h>
 #include <ATen/AccumulateType.h>
-#include <ATen/CUDAGeneratorImpl.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/core/TensorAccessor.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAGeneratorImpl.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <cuda.h>
 #include <cuda_runtime.h>


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/FBGEMM/pull/860

This patch follows up D33414890.

This patch removes an alias header "`ATen/CUDAGeneratorImpl.h`" since it has been moved to `ATen/cuda/CUDAGeneratorImpl.h`. This change should have already been propagated.

Differential Revision: D33534276

